### PR TITLE
Legger til støtte for nye felt fra handler relatert til ekstern varsling

### DIFF
--- a/src/main/kotlin/no/nav/tms/event/api/beskjed/Beskjed.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/beskjed/Beskjed.kt
@@ -18,5 +18,7 @@ data class Beskjed(
     val synligFremTil: ZonedDateTime? = null,
     val tekst: String,
     val link: String,
-    val aktiv: Boolean
+    val aktiv: Boolean,
+    val eksternVarslingSendt: Boolean,
+    val eksternVarslingKanaler: List<String>
 )

--- a/src/main/kotlin/no/nav/tms/event/api/beskjed/BeskjedDTO.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/beskjed/BeskjedDTO.kt
@@ -1,5 +1,5 @@
 @file:UseSerializers(ZonedDateTimeSerializer::class)
-package no.nav.tms.event.api.oppgave
+package no.nav.tms.event.api.beskjed
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -7,7 +7,7 @@ import no.nav.tms.event.api.common.serializer.ZonedDateTimeSerializer
 import java.time.ZonedDateTime
 
 @Serializable
-data class Oppgave(
+data class BeskjedDTO(
     val fodselsnummer: String,
     val grupperingsId: String,
     val eventId: String,
@@ -15,9 +15,8 @@ data class Oppgave(
     val produsent: String,
     val sikkerhetsnivaa: Int,
     val sistOppdatert: ZonedDateTime,
+    val synligFremTil: ZonedDateTime? = null,
     val tekst: String,
     val link: String,
-    val aktiv: Boolean,
-    val eksternVarslingSendt: Boolean,
-    val eksternVarslingKanaler: List<String>
+    val aktiv: Boolean
 )

--- a/src/main/kotlin/no/nav/tms/event/api/beskjed/BeskjedEventService.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/beskjed/BeskjedEventService.kt
@@ -2,27 +2,35 @@ package no.nav.tms.event.api.beskjed
 
 import no.nav.tms.event.api.common.AzureTokenFetcher
 import no.nav.tms.event.api.common.User
+import no.nav.tms.event.api.beskjed.Beskjed
+import no.nav.tms.event.api.beskjed.BeskjedDTO
 
 class BeskjedEventService(
     private val beskjedConsumer: BeskjedConsumer,
     private val azureTokenFetcher: AzureTokenFetcher
 ) {
 
-    suspend fun getActiveCachedEventsForUser(bruker: User): List<Beskjed> {
+    suspend fun getActiveCachedEventsForUser(bruker: User): List<BeskjedDTO> {
         val azureToken = azureTokenFetcher.fetchTokenForEventHandler()
 
-        return beskjedConsumer.getActiveEvents(azureToken, bruker.fodselsnummer)
+        val beskjedList = beskjedConsumer.getActiveEvents(azureToken, bruker.fodselsnummer)
+
+        return BeskjedTransformer.toBeskjedDTO(beskjedList)
     }
 
-    suspend fun getInactiveCachedEventsForUser(bruker: User): List<Beskjed> {
+    suspend fun getInactiveCachedEventsForUser(bruker: User): List<BeskjedDTO> {
         val azureToken = azureTokenFetcher.fetchTokenForEventHandler()
 
-        return beskjedConsumer.getInactiveEvents(azureToken, bruker.fodselsnummer)
+        val beskjedList = beskjedConsumer.getInactiveEvents(azureToken, bruker.fodselsnummer)
+
+        return BeskjedTransformer.toBeskjedDTO(beskjedList)
     }
 
-    suspend fun getAllCachedEventsForUser(bruker: User): List<Beskjed> {
+    suspend fun getAllCachedEventsForUser(bruker: User): List<BeskjedDTO> {
         val azureToken = azureTokenFetcher.fetchTokenForEventHandler()
 
-        return beskjedConsumer.getAllEvents(azureToken, bruker.fodselsnummer)
+        val beskjedList = beskjedConsumer.getAllEvents(azureToken, bruker.fodselsnummer)
+
+        return BeskjedTransformer.toBeskjedDTO(beskjedList)
     }
 }

--- a/src/main/kotlin/no/nav/tms/event/api/beskjed/BeskjedTransformer.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/beskjed/BeskjedTransformer.kt
@@ -1,0 +1,26 @@
+package no.nav.tms.event.api.beskjed
+
+object BeskjedTransformer {
+    fun toBeskjedDTO(beskjedList: List<Beskjed>): List<BeskjedDTO> {
+        return beskjedList.map {
+            toBeskjedDTO(it)
+        }
+    }
+
+    private fun toBeskjedDTO(beskjed: Beskjed): BeskjedDTO =
+        beskjed.let {
+            BeskjedDTO(
+                forstBehandlet = it.forstBehandlet,
+                eventId = it.eventId,
+                fodselsnummer = it.fodselsnummer,
+                tekst = it.tekst,
+                link = it.link,
+                produsent = it.produsent,
+                sistOppdatert = it.sistOppdatert,
+                sikkerhetsnivaa = it.sikkerhetsnivaa,
+                aktiv = it.aktiv,
+                grupperingsId = it.grupperingsId
+            )
+        }
+}
+

--- a/src/main/kotlin/no/nav/tms/event/api/innboks/Innboks.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/innboks/Innboks.kt
@@ -17,5 +17,7 @@ data class Innboks(
     val link: String,
     val sikkerhetsnivaa: Int,
     val sistOppdatert: ZonedDateTime,
-    val aktiv: Boolean
+    val aktiv: Boolean,
+    val eksternVarslingSendt: Boolean,
+    val eksternVarslingKanaler: List<String>
 )

--- a/src/main/kotlin/no/nav/tms/event/api/innboks/InnboksDTO.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/innboks/InnboksDTO.kt
@@ -1,5 +1,5 @@
 @file:UseSerializers(ZonedDateTimeSerializer::class)
-package no.nav.tms.event.api.oppgave
+package no.nav.tms.event.api.innboks
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
@@ -7,17 +7,15 @@ import no.nav.tms.event.api.common.serializer.ZonedDateTimeSerializer
 import java.time.ZonedDateTime
 
 @Serializable
-data class Oppgave(
-    val fodselsnummer: String,
-    val grupperingsId: String,
-    val eventId: String,
-    val forstBehandlet: ZonedDateTime,
+data class InnboksDTO(
     val produsent: String,
-    val sikkerhetsnivaa: Int,
-    val sistOppdatert: ZonedDateTime,
+    val forstBehandlet: ZonedDateTime,
+    val fodselsnummer: String,
+    val eventId: String,
+    val grupperingsId: String,
     val tekst: String,
     val link: String,
-    val aktiv: Boolean,
-    val eksternVarslingSendt: Boolean,
-    val eksternVarslingKanaler: List<String>
+    val sikkerhetsnivaa: Int,
+    val sistOppdatert: ZonedDateTime,
+    val aktiv: Boolean
 )

--- a/src/main/kotlin/no/nav/tms/event/api/innboks/InnboksEventService.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/innboks/InnboksEventService.kt
@@ -2,27 +2,35 @@ package no.nav.tms.event.api.innboks
 
 import no.nav.tms.event.api.common.AzureTokenFetcher
 import no.nav.tms.event.api.common.User
+import no.nav.tms.event.api.innboks.Innboks
+import no.nav.tms.event.api.innboks.InnboksDTO
 
 class InnboksEventService(
     private val innboksConsumer: InnboksConsumer,
     private val azureTokenFetcher: AzureTokenFetcher
 ) {
 
-    suspend fun getActiveCachedEventsForUser(bruker: User): List<Innboks> {
+    suspend fun getActiveCachedEventsForUser(bruker: User): List<InnboksDTO> {
         val azureToken = azureTokenFetcher.fetchTokenForEventHandler()
 
-        return innboksConsumer.getActiveEvents(azureToken, bruker.fodselsnummer)
+        val innboksList = innboksConsumer.getActiveEvents(azureToken, bruker.fodselsnummer)
+
+        return InnboksTransformer.toInnboksDTO(innboksList)
     }
 
-    suspend fun getInactiveCachedEventsForUser(bruker: User): List<Innboks> {
+    suspend fun getInactiveCachedEventsForUser(bruker: User): List<InnboksDTO> {
         val azureToken = azureTokenFetcher.fetchTokenForEventHandler()
 
-        return innboksConsumer.getInactiveEvents(azureToken, bruker.fodselsnummer)
+        val innboksList = innboksConsumer.getInactiveEvents(azureToken, bruker.fodselsnummer)
+
+        return InnboksTransformer.toInnboksDTO(innboksList)
     }
 
-    suspend fun getAllCachedEventsForUser(bruker: User): List<Innboks> {
+    suspend fun getAllCachedEventsForUser(bruker: User): List<InnboksDTO> {
         val azureToken = azureTokenFetcher.fetchTokenForEventHandler()
 
-        return innboksConsumer.getAllEvents(azureToken, bruker.fodselsnummer)
+        val innboksList = innboksConsumer.getAllEvents(azureToken, bruker.fodselsnummer)
+
+        return InnboksTransformer.toInnboksDTO(innboksList)
     }
 }

--- a/src/main/kotlin/no/nav/tms/event/api/innboks/InnboksTransformer.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/innboks/InnboksTransformer.kt
@@ -1,0 +1,26 @@
+package no.nav.tms.event.api.innboks
+
+object InnboksTransformer {
+    fun toInnboksDTO(innboksList: List<Innboks>): List<InnboksDTO> {
+        return innboksList.map {
+            toInnboksDTO(it)
+        }
+    }
+
+    private fun toInnboksDTO(innboks: Innboks): InnboksDTO =
+        innboks.let {
+            InnboksDTO(
+                forstBehandlet = it.forstBehandlet,
+                eventId = it.eventId,
+                fodselsnummer = it.fodselsnummer,
+                tekst = it.tekst,
+                link = it.link,
+                produsent = it.produsent,
+                sistOppdatert = it.sistOppdatert,
+                sikkerhetsnivaa = it.sikkerhetsnivaa,
+                aktiv = it.aktiv,
+                grupperingsId = it.grupperingsId
+            )
+        }
+}
+

--- a/src/main/kotlin/no/nav/tms/event/api/oppgave/OppgaveDTO.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/oppgave/OppgaveDTO.kt
@@ -7,7 +7,7 @@ import no.nav.tms.event.api.common.serializer.ZonedDateTimeSerializer
 import java.time.ZonedDateTime
 
 @Serializable
-data class Oppgave(
+data class OppgaveDTO(
     val fodselsnummer: String,
     val grupperingsId: String,
     val eventId: String,
@@ -17,7 +17,5 @@ data class Oppgave(
     val sistOppdatert: ZonedDateTime,
     val tekst: String,
     val link: String,
-    val aktiv: Boolean,
-    val eksternVarslingSendt: Boolean,
-    val eksternVarslingKanaler: List<String>
+    val aktiv: Boolean
 )

--- a/src/main/kotlin/no/nav/tms/event/api/oppgave/OppgaveEventService.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/oppgave/OppgaveEventService.kt
@@ -8,21 +8,27 @@ class OppgaveEventService(
     private val azureTokenFetcher: AzureTokenFetcher
 ) {
 
-    suspend fun getActiveCachedEventsForUser(bruker: User): List<Oppgave> {
+    suspend fun getActiveCachedEventsForUser(bruker: User): List<OppgaveDTO> {
         val azureToken = azureTokenFetcher.fetchTokenForEventHandler()
 
-        return oppgaveConsumer.getActiveEvents(azureToken, bruker.fodselsnummer)
+        val oppgaveList = oppgaveConsumer.getActiveEvents(azureToken, bruker.fodselsnummer)
+
+        return OppgaveTransformer.toOppgaveDTO(oppgaveList)
     }
 
-    suspend fun getInactiveCachedEventsForUser(bruker: User): List<Oppgave> {
+    suspend fun getInactiveCachedEventsForUser(bruker: User): List<OppgaveDTO> {
         val azureToken = azureTokenFetcher.fetchTokenForEventHandler()
 
-        return oppgaveConsumer.getInactiveEvents(azureToken, bruker.fodselsnummer)
+        val oppgaveList = oppgaveConsumer.getInactiveEvents(azureToken, bruker.fodselsnummer)
+
+        return OppgaveTransformer.toOppgaveDTO(oppgaveList)
     }
 
-    suspend fun getAllCachedEventsForUser(bruker: User): List<Oppgave> {
+    suspend fun getAllCachedEventsForUser(bruker: User): List<OppgaveDTO> {
         val azureToken = azureTokenFetcher.fetchTokenForEventHandler()
 
-        return oppgaveConsumer.getAllEvents(azureToken, bruker.fodselsnummer)
+        val oppgaveList = oppgaveConsumer.getAllEvents(azureToken, bruker.fodselsnummer)
+
+        return OppgaveTransformer.toOppgaveDTO(oppgaveList)
     }
 }

--- a/src/main/kotlin/no/nav/tms/event/api/oppgave/OppgaveTransformer.kt
+++ b/src/main/kotlin/no/nav/tms/event/api/oppgave/OppgaveTransformer.kt
@@ -1,0 +1,26 @@
+package no.nav.tms.event.api.oppgave
+
+object OppgaveTransformer {
+    fun toOppgaveDTO(oppgaveList: List<Oppgave>): List<OppgaveDTO> {
+        return oppgaveList.map {
+            toOppgaveDTO(it)
+        }
+    }
+
+    private fun toOppgaveDTO(oppgave: Oppgave): OppgaveDTO =
+        oppgave.let {
+            OppgaveDTO(
+                forstBehandlet = it.forstBehandlet,
+                eventId = it.eventId,
+                fodselsnummer = it.fodselsnummer,
+                tekst = it.tekst,
+                link = it.link,
+                produsent = it.produsent,
+                sistOppdatert = it.sistOppdatert,
+                sikkerhetsnivaa = it.sikkerhetsnivaa,
+                aktiv = it.aktiv,
+                grupperingsId = it.grupperingsId
+            )
+        }
+}
+


### PR DESCRIPTION
Støtter nye felt relatert til ekstern varsling fra handler.

Nye felt er ikke inkludert i objektet som sendes downstream, men kan legges til når konsumenter er klare. 

Må merges sammen med https://github.com/navikt/dittnav-event-handler/pull/142